### PR TITLE
Fix the build with -Zminimal-versions

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -7,8 +7,14 @@ task:
   setup_script:
     - fetch https://sh.rustup.rs -o rustup.sh
     - sh rustup.sh -y
+    - $HOME/.cargo/bin/rustup toolchain install nightly
     # In 11.3, aio on ufs is considered unsafe
     - sysctl vfs.aio.enable_unsafe=1
   test_script:
     - . $HOME/.cargo/env
     - cargo test
+  # Test our minimal version spec.
+  minver_test_script:
+    - . $HOME/.cargo/env
+    - cargo +nightly update -Zminimal-versions
+    - cargo +nightly check --all-targets

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ documentation = "https://asomers.github.io/mio-aio/mio_aio/"
 
 [dependencies]
 mio = "0.6.13"
-nix = "0.*.1, >= 0.12.1"
+nix = "0.15.0"
 
 [dev-dependencies]
 divbuf = "0.2.0"


### PR DESCRIPTION
It's necessary to raise the dependency on Nix, just because Nix itself
didn't build with -Zminimal-versions until version 0.15.0