### PR TITLE
Adapt to the world of async/await

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ documentation = "https://asomers.github.io/mio-aio/mio_aio/"
 
 [dependencies]
 mio = "0.6.13"
-nix = { git = "https://github.com/asomers/nix", rev = "7912d9cfb10ea3a8118f00eb5a40790cdea33c8d" }
+nix = "0.21.0"
 
 [dev-dependencies]
 log = "0.3.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ documentation = "https://asomers.github.io/mio-aio/mio_aio/"
 
 [dependencies]
 mio = "0.6.13"
-nix = "0.15.0"
+nix = { git = "https://github.com/asomers/nix", rev = "a60f8edc13028648a1124c677f9dfa4ecac3caf7" }
 
 [dev-dependencies]
 divbuf = "0.2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,10 +14,9 @@ documentation = "https://asomers.github.io/mio-aio/mio_aio/"
 
 [dependencies]
 mio = "0.6.13"
-nix = { git = "https://github.com/asomers/nix", rev = "5d2354517a643162bdc6608a5a30aba43f592069" }
+nix = { git = "https://github.com/asomers/nix", rev = "7912d9cfb10ea3a8118f00eb5a40790cdea33c8d" }
 
 [dev-dependencies]
-divbuf = "0.2.0"
 log = "0.3.4"
 sysctl = "0.1"
 tempfile = "3.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ documentation = "https://asomers.github.io/mio-aio/mio_aio/"
 
 [dependencies]
 mio = "0.6.13"
-nix = { git = "https://github.com/asomers/nix", rev = "a60f8edc13028648a1124c677f9dfa4ecac3caf7" }
+nix = { git = "https://github.com/asomers/nix", rev = "5d2354517a643162bdc6608a5a30aba43f592069" }
 
 [dev-dependencies]
 divbuf = "0.2.0"

--- a/src/aio.rs
+++ b/src/aio.rs
@@ -155,7 +155,7 @@ impl<'a> LioCb<'a> {
                 let mut n_einprogress = 0;
                 let mut n_eagain = 0;
                 let mut n_ok = 0;
-                let errors = (0..self.inner.aiocbs.len())
+                let errors = (0..self.inner.len())
                 .map(|i| {
                     self.inner.error(i).map_err(|e| e.as_errno().unwrap())
                 }).collect::<Vec<_>>();
@@ -184,9 +184,9 @@ impl<'a> LioCb<'a> {
                 if n_error > 0 {
                     // Collect final status for every operation
                     Err(LioError::EIO(errors))
-                } else if n_eagain > 0 && n_eagain < self.inner.aiocbs.len() {
+                } else if n_eagain > 0 && n_eagain < self.inner.len() {
                     Err(LioError::EINCOMPLETE)
-                } else if n_eagain == self.inner.aiocbs.len() {
+                } else if n_eagain == self.inner.len() {
                     Err(LioError::EAGAIN)
                 } else {
                     panic!("lio_listio returned EIO for unknown reasons.  n_error={}, n_einprogress={}, n_eagain={}, and n_ok={}",
@@ -243,7 +243,7 @@ impl<'a> LioCb<'a> {
         where F: FnOnce(Box<dyn Iterator<Item=LioResult> + 'a>) -> R {
 
         let mut inner = self.inner;
-        let iter = (0..inner.aiocbs.len()).map(move |i| {
+        let iter = (0..inner.len()).map(move |i| {
             let result = inner.aio_return(i);
             LioResult{result }
         });

--- a/src/aio.rs
+++ b/src/aio.rs
@@ -228,7 +228,7 @@ pub struct LioCb {
 }
 // LCOV_EXCL_STOP
 
-impl<'a> LioCb {
+impl LioCb {
     /// Translate the operating system's somewhat unhelpful error from
     /// `lio_listio` into something more useful.
     fn fix_submit_error(&mut self, e: nix::Result<()>) -> Result<(), LioError> {
@@ -347,7 +347,7 @@ impl<'a> LioCb {
     // allocations and still allows the caller to use an iterator adapter with
     // the results.
     pub fn into_results<F, R>(self, callback: F) -> R
-        where F: FnOnce(Box<dyn Iterator<Item=LioResult> + 'a>) -> R {
+        where F: FnOnce(Box<dyn Iterator<Item=LioResult>>) -> R {
 
         let mut inner = self.inner;
         let iter = (0..inner.aiocbs.len()).map(move |i| {

--- a/src/aio.rs
+++ b/src/aio.rs
@@ -26,9 +26,9 @@ pub enum BufRef {
     /// reference can't be stored, as when constructed from a slice
     None,
     /// Immutable generic boxed slice
-    BoxedSlice(Box<dyn Borrow<[u8]>>),
+    BoxedSlice(Box<dyn Borrow<[u8]> + Send + Sync>),
     /// Mutable generic boxed slice
-    BoxedMutSlice(Box<dyn BorrowMut<[u8]> + Send+ Sync>)
+    BoxedMutSlice(Box<dyn BorrowMut<[u8]> + Send + Sync>)
 }
 
 // is_empty wouldn't make sense because our len returns an Option

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,5 +5,6 @@ extern crate nix;
 
 mod aio;
 
-pub use aio::{AioCb, AioFsyncMode, BufRef, LioCb, LioOpcode, LioError};
+pub use aio::{AioCb, AioFsyncMode, BufRef, LioCb, LioCbBuilder, LioOpcode,
+    LioError};
 pub use nix::errno::Errno;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,6 @@ extern crate nix;
 
 mod aio;
 
-pub use aio::{AioCb, AioFsyncMode, BufRef, LioCb, LioCbBuilder, LioOpcode,
+pub use aio::{AioCb, AioFsyncMode, LioCb, LioCbBuilder, LioOpcode,
     LioError};
 pub use nix::errno::Errno;

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1,9 +1,7 @@
-extern crate divbuf;
 extern crate mio;
 extern crate mio_aio;
 extern crate tempfile;
 
-use divbuf::DivBufShared;
 use mio::{Events, Poll, PollOpt, Token};
 use mio::unix::UnixReady;
 use tempfile::tempfile;
@@ -103,77 +101,7 @@ pub fn test_aio_read() {
 }
 
 #[test]
-pub fn test_aio_read_divbuf() {
-    const INITIAL: &[u8] = b"abcdef";
-    let dbs = DivBufShared::from(vec![0u8; 4]);
-    let rbuf = Box::new(dbs.try_mut().unwrap());
-    const EXPECT: &[u8] = b"cdef";
-    let mut f = tempfile().unwrap();
-    f.write_all(INITIAL).unwrap();
-
-    let poll = Poll::new().unwrap();
-    let mut events = Events::with_capacity(1024);
-    let mut aiocb = mio_aio::AioCb::from_boxed_mut_slice(f.as_raw_fd(),
-        2,   //offset
-        rbuf,
-        0,   //priority
-        mio_aio::LioOpcode::LIO_NOP);
-    poll.register(&aiocb, UDATA, UnixReady::aio().into(), PollOpt::empty())
-        .expect("registration failed");
-
-    aiocb.read().unwrap();
-
-    poll.poll(&mut events, None).expect("poll failed");
-    let mut it = events.iter();
-    let ev = it.next().unwrap();
-    assert_eq!(ev.token(), UDATA);
-    assert!(UnixReady::from(ev.readiness()).is_aio());
-
-    assert!(aiocb.error().is_ok());
-    assert_eq!(aiocb.aio_return().unwrap(), EXPECT.len() as isize);
-    let mut buf_ref = aiocb.buf_ref();
-    assert_eq!(buf_ref.boxed_mut_slice().unwrap().borrow(), EXPECT);
-    assert!(it.next().is_none());
-}
-
-#[test]
-pub fn test_aio_write_divbuf() {
-    let dbs = DivBufShared::from(&b"abcdef"[..]);
-    let wbuf = Box::new(dbs.try().unwrap());
-    let mut f = tempfile().unwrap();
-    let mut rbuf = Vec::new();
-
-    let poll = Poll::new().unwrap();
-    let mut events = Events::with_capacity(1024);
-    let mut aiocb = mio_aio::AioCb::from_boxed_slice(f.as_raw_fd(),
-        0,   //offset
-        wbuf.clone(),
-        0,   //priority
-        mio_aio::LioOpcode::LIO_NOP);
-    poll.register(&aiocb, UDATA, UnixReady::aio().into(), PollOpt::empty())
-        .expect("registration failed");
-
-    aiocb.write().unwrap();
-
-    poll.poll(&mut events, None).expect("poll failed");
-    let mut it = events.iter();
-    let ev = it.next().unwrap();
-    assert_eq!(ev.token(), UDATA);
-    assert!(UnixReady::from(ev.readiness()).is_aio());
-
-    assert!(aiocb.error().is_ok());
-    assert_eq!(aiocb.aio_return().unwrap(), wbuf.len() as isize);
-    f.seek(SeekFrom::Start(0)).unwrap();
-    let len = f.read_to_end(&mut rbuf).unwrap();
-    assert!(len == wbuf.len());
-    assert!(rbuf == wbuf.deref().deref());
-    let buf_ref = aiocb.buf_ref();
-    assert_eq!(buf_ref.boxed_slice().unwrap().borrow(), &wbuf[..]);
-    assert!(it.next().is_none());
-}
-
-#[test]
-pub fn test_aio_write_slice() {
+pub fn test_aio_write() {
     let wbuf = String::from("abcdef").into_bytes().into_boxed_slice();
     let mut f = tempfile().unwrap();
     let mut rbuf = Vec::new();
@@ -241,13 +169,12 @@ pub fn test_aio_write_static() {
 // lio_listio returns EIO because one of its children failed
 #[test]
 pub fn test_lio_eio() {
-    let dbs = DivBufShared::from(&b"abcdef"[..]);
-    let wbuf0 = Box::new(dbs.try().unwrap());
+    let wbuf0 = &b"abcdef"[..];
     let poll = Poll::new().unwrap();
 
     let mut builder = mio_aio::LioCbBuilder::with_capacity(1);
     let fd = -1;    // Illegal file descriptor
-    builder = builder.emplace_boxed_slice(fd, 0, wbuf0, 0,
+    builder = builder.emplace_slice(fd, 0, wbuf0, 0,
                         mio_aio::LioOpcode::LIO_WRITE);
     let mut liocb = builder.finish();
     poll.register(&liocb, UDATA, UnixReady::lio().into(), PollOpt::empty())
@@ -263,15 +190,15 @@ pub fn test_lio_oneread() {
     const INITIAL: &[u8] = b"abcdef123456";
     const EXPECT: &[u8] = b"cdef";
     let mut f = tempfile().unwrap();
-    let dbs = DivBufShared::from(vec![0; 4]);
-    let buf = Box::new(dbs.try_mut().unwrap());
+    //let dbs = DivBufShared::from(vec![0; 4]);
+    let mut buf = vec![0; 4];
     f.write_all(INITIAL).unwrap();
 
     let poll = Poll::new().unwrap();
     let mut events = Events::with_capacity(1024);
 
     let mut builder = mio_aio::LioCbBuilder::with_capacity(1);
-    builder = builder.emplace_boxed_mut_slice(f.as_raw_fd(), 2, buf, 0,
+    builder = builder.emplace_mut_slice(f.as_raw_fd(), 2, &mut buf[..], 0,
         mio_aio::LioOpcode::LIO_READ);
     let mut liocb = builder.finish();
     poll.register(&liocb, UDATA, UnixReady::lio().into(), PollOpt::empty())
@@ -286,18 +213,17 @@ pub fn test_lio_oneread() {
     assert!(UnixReady::from(ev.readiness()).is_lio());
 
     liocb.into_results(|mut iter| {
-        let mut lr = iter.next().unwrap();
+        let lr = iter.next().unwrap();
         assert_eq!(lr.result.unwrap(), EXPECT.len() as isize);
-        assert_eq!(lr.buf_ref.boxed_mut_slice().unwrap().borrow(), EXPECT);
         assert!(iter.next().is_none());
     });
     assert!(it.next().is_none());
+    assert_eq!(&EXPECT[..], &buf[..]);
 }
 
 #[test]
 pub fn test_lio_onewrite() {
-    let dbs = DivBufShared::from(&b"abcdef"[..]);
-    let wbuf0 = Box::new(dbs.try().unwrap());
+    let wbuf = b"abcdef";
     let mut f = tempfile().unwrap();
     let mut rbuf = Vec::new();
 
@@ -305,45 +231,7 @@ pub fn test_lio_onewrite() {
     let mut events = Events::with_capacity(1024);
 
     let mut builder = mio_aio::LioCbBuilder::with_capacity(1);
-    builder = builder.emplace_boxed_slice(f.as_raw_fd(), 0, wbuf0, 0,
-                        mio_aio::LioOpcode::LIO_WRITE);
-    let mut liocb = builder.finish();
-    poll.register(&liocb, UDATA, UnixReady::lio().into(), PollOpt::empty())
-        .expect("registration failed");
-
-    liocb.submit().unwrap();
-
-    poll.poll(&mut events, None).expect("poll failed");
-    let mut it = events.iter();
-    let ev = it.next().unwrap();
-    assert_eq!(ev.token(), UDATA);
-    assert!(UnixReady::from(ev.readiness()).is_lio());
-
-    let wbuf1 = dbs.try().unwrap();
-    liocb.into_results(|mut iter| {
-        let lr = iter.next().unwrap();
-        assert_eq!(lr.result.unwrap(), wbuf1.len() as isize);
-        assert!(iter.next().is_none());
-    });
-    f.seek(SeekFrom::Start(0)).unwrap();
-    let len = f.read_to_end(&mut rbuf).unwrap();
-    assert_eq!(len, wbuf1.len());
-    assert_eq!(&wbuf1[..], &rbuf[..]);
-    assert!(it.next().is_none());
-}
-
-// Write from a constant buffer
-#[test]
-pub fn test_lio_onewrite_from_slice() {
-    const WBUF: &[u8] = b"abcdef";
-    let mut f = tempfile().unwrap();
-    let mut rbuf = Vec::new();
-
-    let poll = Poll::new().unwrap();
-    let mut events = Events::with_capacity(1024);
-
-    let mut builder = mio_aio::LioCbBuilder::with_capacity(1);
-    builder = builder.emplace_slice(f.as_raw_fd(), 0, WBUF, 0,
+    builder = builder.emplace_slice(f.as_raw_fd(), 0, &wbuf[..], 0,
                         mio_aio::LioOpcode::LIO_WRITE);
     let mut liocb = builder.finish();
     poll.register(&liocb, UDATA, UnixReady::lio().into(), PollOpt::empty())
@@ -359,13 +247,13 @@ pub fn test_lio_onewrite_from_slice() {
 
     liocb.into_results(|mut iter| {
         let lr = iter.next().unwrap();
-        assert_eq!(lr.result.unwrap(), WBUF.len() as isize);
+        assert_eq!(lr.result.unwrap(), wbuf.len() as isize);
         assert!(iter.next().is_none());
     });
     f.seek(SeekFrom::Start(0)).unwrap();
     let len = f.read_to_end(&mut rbuf).unwrap();
-    assert_eq!(len, WBUF.len());
-    assert_eq!(rbuf, WBUF);
+    assert_eq!(len, wbuf.len());
+    assert_eq!(&wbuf[..], &rbuf[..]);
     assert!(it.next().is_none());
 }
 
@@ -375,19 +263,17 @@ pub fn test_lio_tworeads() {
     const EXPECT0: &[u8] = b"cdef";
     const EXPECT1: &[u8] = b"23456";
     let mut f = tempfile().unwrap();
-    let dbs0 = DivBufShared::from(vec![0; 4]);
-    let rbuf0 = Box::new(dbs0.try_mut().unwrap());
-    let dbs1 = DivBufShared::from(vec![0; 5]);
-    let rbuf1 = Box::new(dbs1.try_mut().unwrap());
+    let mut rbuf0 = vec![0; 4];
+    let mut rbuf1 = vec![0; 5];
     f.write_all(INITIAL).unwrap();
 
     let poll = Poll::new().unwrap();
     let mut events = Events::with_capacity(1024);
 
     let mut builder = mio_aio::LioCbBuilder::with_capacity(2);
-    builder = builder.emplace_boxed_mut_slice(f.as_raw_fd(), 2, rbuf0, 0,
+    builder = builder.emplace_mut_slice(f.as_raw_fd(), 2, &mut rbuf0[..], 0,
                             mio_aio::LioOpcode::LIO_READ);
-    builder = builder.emplace_boxed_mut_slice(f.as_raw_fd(), 7, rbuf1, 0,
+    builder = builder.emplace_mut_slice(f.as_raw_fd(), 7, &mut rbuf1[..], 0,
                             mio_aio::LioOpcode::LIO_READ);
     let mut liocb = builder.finish();
     poll.register(&liocb, UDATA, UnixReady::lio().into(), PollOpt::empty())
@@ -402,14 +288,14 @@ pub fn test_lio_tworeads() {
     assert!(UnixReady::from(ev.readiness()).is_lio());
 
     liocb.into_results(|mut iter| {
-        let mut lr0 = iter.next().unwrap();
+        let lr0 = iter.next().unwrap();
         assert_eq!(lr0.result.unwrap(), EXPECT0.len() as isize);
-        assert_eq!(lr0.buf_ref.boxed_mut_slice().unwrap().borrow(), EXPECT0);
-        let mut lr1 = iter.next().unwrap();
+        let lr1 = iter.next().unwrap();
         assert_eq!(lr1.result.unwrap(), EXPECT1.len() as isize);
-        assert_eq!(lr1.buf_ref.boxed_mut_slice().unwrap().borrow(), EXPECT1);
         assert!(iter.next().is_none());
     });
+    assert_eq!(&rbuf0[..], EXPECT0);
+    assert_eq!(&rbuf1[..], EXPECT1);
 
     assert!(it.next().is_none());
 }
@@ -421,8 +307,7 @@ pub fn test_lio_read_and_write() {
     const EXPECT0: &[u8] = b"cdef";
     let mut f0 = tempfile().unwrap();
     let mut f1 = tempfile().unwrap();
-    let dbs0 = DivBufShared::from(vec![0; 4]);
-    let rbuf0 = Box::new(dbs0.try_mut().unwrap());
+    let mut rbuf0 = vec![0; 4];
     let mut rbuf1 = Vec::new();
     f0.write_all(INITIAL0).unwrap();
 
@@ -430,7 +315,7 @@ pub fn test_lio_read_and_write() {
     let mut events = Events::with_capacity(1024);
 
     let mut builder = mio_aio::LioCbBuilder::with_capacity(2);
-    builder = builder.emplace_boxed_mut_slice(f0.as_raw_fd(), 2, rbuf0, 0,
+    builder = builder.emplace_mut_slice(f0.as_raw_fd(), 2, &mut rbuf0[..], 0,
                             mio_aio::LioOpcode::LIO_READ);
     builder = builder.emplace_slice(f1.as_raw_fd(), 0, WBUF1, 0,
                         mio_aio::LioOpcode::LIO_WRITE);
@@ -447,91 +332,20 @@ pub fn test_lio_read_and_write() {
     assert!(UnixReady::from(ev.readiness()).is_lio());
 
     liocb.into_results(|mut iter| {
-        let mut lr0 = iter.next().unwrap();
+        let lr0 = iter.next().unwrap();
         assert_eq!(lr0.result.unwrap(), EXPECT0.len() as isize);
-        assert_eq!(lr0.buf_ref.boxed_mut_slice().unwrap().borrow(), EXPECT0);
 
         let lr1 = iter.next().unwrap();
         assert_eq!(lr1.result.unwrap(), WBUF1.len() as isize);
 
         assert!(iter.next().is_none());
     });
+    assert_eq!(&rbuf0[..], EXPECT0);
 
     f1.seek(SeekFrom::Start(0)).unwrap();
     let len = f1.read_to_end(&mut rbuf1).unwrap();
     assert_eq!(len, WBUF1.len());
     assert_eq!(rbuf1, WBUF1);
-
-    assert!(it.next().is_none());
-}
-
-// An lio operation that contains every variant of BufRef.  Tests retrieving the
-// BufRefs once the operation is complete.
-// Op 1: write from static slice
-// Op 4: write from BoxedSlice
-// Op 5: read into BoxedMutSlice
-#[test]
-pub fn test_lio_buf_ref() {
-    const INITIAL: &[u8] = b"abcdefghijklmnopqrstuvwxyz";
-    const WBUF1: &[u8] = b"AB";
-    let mut rbuf1 = vec![0u8; 2];
-    let dbs4 = DivBufShared::from(&b"QXYZ"[..]);
-    let db4 = Box::new(dbs4.try().unwrap());
-    let mut rbuf4 = vec![0u8; 4];
-    let dbs5 = DivBufShared::from(vec![0; 8]);
-    let dbm5 = Box::new(dbs5.try_mut().unwrap());
-    const EXPECT5: &[u8] = b"qrstuvwx";
-    let mut f = tempfile().unwrap();
-    f.write_all(INITIAL).unwrap();
-
-    let poll = Poll::new().unwrap();
-    let mut events = Events::with_capacity(1024);
-
-    let mut builder = mio_aio::LioCbBuilder::with_capacity(3);
-    builder = builder.emplace_slice(f.as_raw_fd(), 0, WBUF1, 0,
-                        mio_aio::LioOpcode::LIO_WRITE);
-    builder = builder.emplace_boxed_slice(f.as_raw_fd(), 6, db4, 0,
-                              mio_aio::LioOpcode::LIO_WRITE);
-    builder = builder.emplace_boxed_mut_slice(f.as_raw_fd(), 16, dbm5, 0,
-                              mio_aio::LioOpcode::LIO_READ);
-    let mut liocb = builder.finish();
-    poll.register(&liocb, UDATA, UnixReady::lio().into(), PollOpt::empty())
-        .expect("registration failed");
-
-    liocb.submit().unwrap();
-
-    poll.poll(&mut events, None).expect("poll failed");
-    let mut it = events.iter();
-    let ev = it.next().unwrap();
-    assert_eq!(ev.token(), UDATA);
-    assert!(UnixReady::from(ev.readiness()).is_lio());
-
-    liocb.into_results(|mut iter| {
-        let lr0 = iter.next().unwrap();
-        f.seek(SeekFrom::Start(0)).unwrap();
-        let len = f.read(&mut rbuf1).unwrap();
-        assert_eq!(len, WBUF1.len());
-        assert_eq!(rbuf1, WBUF1);
-        assert_eq!(lr0.result.unwrap(), WBUF1.len() as isize);
-        assert!(lr0.buf_ref.is_none());
-        assert_eq!(lr0.buf_ref.len(), None);
-
-        let lr1 = iter.next().unwrap();
-        assert_eq!(lr1.result.unwrap(), dbs4.len() as isize);
-        f.seek(SeekFrom::Start(6)).unwrap();
-        let len = f.read(&mut rbuf4).unwrap();
-        assert_eq!(len, dbs4.len());
-        assert_eq!(rbuf4[..], dbs4.try().unwrap()[..]);
-        assert_eq!(lr1.buf_ref.boxed_slice().unwrap().borrow(), &rbuf4[..]);
-        assert_eq!(lr1.buf_ref.len(), Some(4));
-
-        let mut lr2 = iter.next().unwrap();
-        assert_eq!(lr2.result.unwrap(), EXPECT5.len() as isize);
-        assert_eq!(lr2.buf_ref.boxed_mut_slice().unwrap().borrow(), &EXPECT5[..]);
-        assert_eq!(lr2.buf_ref.len(), Some(8));
-
-        assert!(iter.next().is_none());
-    });
 
     assert!(it.next().is_none());
 }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -245,10 +245,11 @@ pub fn test_lio_eio() {
     let wbuf0 = Box::new(dbs.try().unwrap());
     let poll = Poll::new().unwrap();
 
-    let mut liocb = mio_aio::LioCb::with_capacity(1);
+    let mut builder = mio_aio::LioCbBuilder::with_capacity(1);
     let fd = -1;    // Illegal file descriptor
-    liocb.emplace_boxed_slice(fd, 0, wbuf0, 0,
+    builder = builder.emplace_boxed_slice(fd, 0, wbuf0, 0,
                         mio_aio::LioOpcode::LIO_WRITE);
+    let mut liocb = builder.finish();
     poll.register(&liocb, UDATA, UnixReady::lio().into(), PollOpt::empty())
         .expect("registration failed");
 
@@ -269,9 +270,10 @@ pub fn test_lio_oneread() {
     let poll = Poll::new().unwrap();
     let mut events = Events::with_capacity(1024);
 
-    let mut liocb = mio_aio::LioCb::with_capacity(1);
-    liocb.emplace_boxed_mut_slice(f.as_raw_fd(), 2, buf, 0,
+    let mut builder = mio_aio::LioCbBuilder::with_capacity(1);
+    builder = builder.emplace_boxed_mut_slice(f.as_raw_fd(), 2, buf, 0,
         mio_aio::LioOpcode::LIO_READ);
+    let mut liocb = builder.finish();
     poll.register(&liocb, UDATA, UnixReady::lio().into(), PollOpt::empty())
         .expect("registration failed");
 
@@ -302,9 +304,10 @@ pub fn test_lio_onewrite() {
     let poll = Poll::new().unwrap();
     let mut events = Events::with_capacity(1024);
 
-    let mut liocb = mio_aio::LioCb::with_capacity(1);
-    liocb.emplace_boxed_slice(f.as_raw_fd(), 0, wbuf0, 0,
+    let mut builder = mio_aio::LioCbBuilder::with_capacity(1);
+    builder = builder.emplace_boxed_slice(f.as_raw_fd(), 0, wbuf0, 0,
                         mio_aio::LioOpcode::LIO_WRITE);
+    let mut liocb = builder.finish();
     poll.register(&liocb, UDATA, UnixReady::lio().into(), PollOpt::empty())
         .expect("registration failed");
 
@@ -339,9 +342,10 @@ pub fn test_lio_onewrite_from_slice() {
     let poll = Poll::new().unwrap();
     let mut events = Events::with_capacity(1024);
 
-    let mut liocb = mio_aio::LioCb::with_capacity(1);
-    liocb.emplace_slice(f.as_raw_fd(), 0, WBUF, 0,
+    let mut builder = mio_aio::LioCbBuilder::with_capacity(1);
+    builder = builder.emplace_slice(f.as_raw_fd(), 0, WBUF, 0,
                         mio_aio::LioOpcode::LIO_WRITE);
+    let mut liocb = builder.finish();
     poll.register(&liocb, UDATA, UnixReady::lio().into(), PollOpt::empty())
         .expect("registration failed");
 
@@ -380,11 +384,12 @@ pub fn test_lio_tworeads() {
     let poll = Poll::new().unwrap();
     let mut events = Events::with_capacity(1024);
 
-    let mut liocb = mio_aio::LioCb::with_capacity(2);
-    liocb.emplace_boxed_mut_slice(f.as_raw_fd(), 2, rbuf0, 0,
+    let mut builder = mio_aio::LioCbBuilder::with_capacity(2);
+    builder = builder.emplace_boxed_mut_slice(f.as_raw_fd(), 2, rbuf0, 0,
                             mio_aio::LioOpcode::LIO_READ);
-    liocb.emplace_boxed_mut_slice(f.as_raw_fd(), 7, rbuf1, 0,
+    builder = builder.emplace_boxed_mut_slice(f.as_raw_fd(), 7, rbuf1, 0,
                             mio_aio::LioOpcode::LIO_READ);
+    let mut liocb = builder.finish();
     poll.register(&liocb, UDATA, UnixReady::lio().into(), PollOpt::empty())
         .expect("registration failed");
 
@@ -424,11 +429,12 @@ pub fn test_lio_read_and_write() {
     let poll = Poll::new().unwrap();
     let mut events = Events::with_capacity(1024);
 
-    let mut liocb = mio_aio::LioCb::with_capacity(2);
-    liocb.emplace_boxed_mut_slice(f0.as_raw_fd(), 2, rbuf0, 0,
+    let mut builder = mio_aio::LioCbBuilder::with_capacity(2);
+    builder = builder.emplace_boxed_mut_slice(f0.as_raw_fd(), 2, rbuf0, 0,
                             mio_aio::LioOpcode::LIO_READ);
-    liocb.emplace_slice(f1.as_raw_fd(), 0, WBUF1, 0,
+    builder = builder.emplace_slice(f1.as_raw_fd(), 0, WBUF1, 0,
                         mio_aio::LioOpcode::LIO_WRITE);
+    let mut liocb = builder.finish();
     poll.register(&liocb, UDATA, UnixReady::lio().into(), PollOpt::empty())
         .expect("registration failed");
 
@@ -481,13 +487,14 @@ pub fn test_lio_buf_ref() {
     let poll = Poll::new().unwrap();
     let mut events = Events::with_capacity(1024);
 
-    let mut liocb = mio_aio::LioCb::with_capacity(3);
-    liocb.emplace_slice(f.as_raw_fd(), 0, WBUF1, 0,
+    let mut builder = mio_aio::LioCbBuilder::with_capacity(3);
+    builder = builder.emplace_slice(f.as_raw_fd(), 0, WBUF1, 0,
                         mio_aio::LioOpcode::LIO_WRITE);
-    liocb.emplace_boxed_slice(f.as_raw_fd(), 6, db4, 0,
+    builder = builder.emplace_boxed_slice(f.as_raw_fd(), 6, db4, 0,
                               mio_aio::LioOpcode::LIO_WRITE);
-    liocb.emplace_boxed_mut_slice(f.as_raw_fd(), 16, dbm5, 0,
+    builder = builder.emplace_boxed_mut_slice(f.as_raw_fd(), 16, dbm5, 0,
                               mio_aio::LioOpcode::LIO_READ);
+    let mut liocb = builder.finish();
     poll.register(&liocb, UDATA, UnixReady::lio().into(), PollOpt::empty())
         .expect("registration failed");
 


### PR DESCRIPTION
With async/await, there is little need for mio-aio to own its buffers.  Instead, it can work with borrowed buffers.  This PR eliminates the owned buffer variants, uses pinned AioCb structures, and readies the crate for use with async/await consumers.