### PR TITLE
Reduce the amount of mutex activity within AioCb

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "mio-aio"
+edition = "2018"
 version = "0.4.2-pre"
 authors = ["Alan Somers <asomers@gmail.com>"]
 license = "MIT/Apache-2.0"
@@ -17,6 +18,7 @@ mio = "0.6.13"
 nix = "0.21.0"
 
 [dev-dependencies]
+assert-impl = "0.1"
 log = "0.3.4"
 sysctl = "0.1"
 tempfile = "3.0"

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -19,7 +19,7 @@ pub fn test_aio_cancel() {
 
     let poll = Poll::new().unwrap();
     let mut events = Events::with_capacity(1024);
-    let aiocb = mio_aio::AioCb::from_slice(f.as_raw_fd(),
+    let mut aiocb = mio_aio::AioCb::from_slice(f.as_raw_fd(),
         0,   //offset
         &WBUF,
         0,   //priority
@@ -50,7 +50,7 @@ pub fn test_aio_fsync() {
     let poll = Poll::new().unwrap();
     let mut events = Events::with_capacity(1024);
 
-    let aiocb = mio_aio::AioCb::from_fd( f.as_raw_fd(), 0);
+    let mut aiocb = mio_aio::AioCb::from_fd( f.as_raw_fd(), 0);
     poll.register(&aiocb, UDATA, UnixReady::aio().into(), PollOpt::empty())
         .expect("registration failed");
 
@@ -77,7 +77,7 @@ pub fn test_aio_read() {
     let poll = Poll::new().unwrap();
     let mut events = Events::with_capacity(1024);
     {
-        let aiocb = mio_aio::AioCb::from_mut_slice(f.as_raw_fd(),
+        let mut aiocb = mio_aio::AioCb::from_mut_slice(f.as_raw_fd(),
             2,   //offset
             &mut rbuf,
             0,   //priority
@@ -108,7 +108,7 @@ pub fn test_aio_write() {
 
     let poll = Poll::new().unwrap();
     let mut events = Events::with_capacity(1024);
-    let aiocb = mio_aio::AioCb::from_slice(f.as_raw_fd(),
+    let mut aiocb = mio_aio::AioCb::from_slice(f.as_raw_fd(),
         0,   //offset
         &wbuf,
         0,   //priority
@@ -141,7 +141,7 @@ pub fn test_aio_write_static() {
 
     let poll = Poll::new().unwrap();
     let mut events = Events::with_capacity(1024);
-    let aiocb = mio_aio::AioCb::from_slice(f.as_raw_fd(),
+    let mut aiocb = mio_aio::AioCb::from_slice(f.as_raw_fd(),
         0,   //offset
         &WBUF,
         0,   //priority


### PR DESCRIPTION
AioCb must wrap its inner nix::aio::AioCb in a mutex because:

* Operations like aio_return require a mutable reference, and so does
  registering the libc::aiocb with kqueue.
* The struct must be Send and Sync to work well with Tokio, which
  precludes options like Refcell.

But locking a mutex is slow.  Speed it up a bit by taking mutable
references in most functions that need to lock the mutex and using
Mutex::get_mut instead of Mutex::lock.  That guarantees exclusive access
at compile-time.  The main operation that still needs to lock the Mutex
is Evented::register, because mio defines that method as taking an
immutable reference.