### PR TITLE
Cargo: use include directives rather than exclude

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ POSIX AIO bindings for mio
 categories = ["asynchronous", "filesystem"]
 keywords = ["io", "async", "non-blocking", "aio"]
 documentation = "https://asomers.github.io/mio-aio/mio_aio/"
-exclude = ["release.toml"]
+include = ["src/**/*", "LICENSE-*", "README.md", "CHANGELOG.md"]
 
 [package.metadata.docs.rs]
 targets = [


### PR DESCRIPTION
cargo-diet seems to be confused by exclude directives