### PR TITLE
Implement io-safety

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -12,7 +12,7 @@ task:
         VERSION: nightly
     - name: FreeBSD 13 amd64 MSRV
       env:
-        VERSION: 1.65.0
+        VERSION: 1.69.0
   # Install Rust
   setup_script:
     - fetch https://sh.rustup.rs -o rustup.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## [Unreleased] - [ReleaseDate]
+
+### Changed
+
+- All types now use I/O Safety.  This means that they take `&BorrowedFd<_>`
+  arguments instead of `RawFd` arguments.  This has serious repurcussions for
+  consumers who intend to create Futures that have `'static` lifetimes.  It all
+  updates the nix dependency to 0.29.0 and updates the MSRV to 1.69.0.
+  (#[42](https://github.com/asomers/mio-aio/pull/42))
+
 ## [0.8.0] - 2023-08-29
 
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ authors = ["Alan Somers <asomers@gmail.com>"]
 license = "MIT/Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/asomers/mio-aio"
+rust-version = "1.69"
 description = """
 POSIX AIO bindings for mio
 """
@@ -26,13 +27,13 @@ tokio = []
 
 [dependencies]
 mio = "0.8.11"
-nix = {version = "0.27.0", default-features = false, features = ["aio", "event"] }
+nix = {version = "0.29.0", default-features = false, features = ["aio", "event"] }
 pin-utils = "0.1.0"
 
 [dev-dependencies]
 assert-impl = "0.1"
 mio = { version = "0.8.11", features = ["os-poll"] }
-nix = {version = "0.27.0", default-features = false, features = ["aio", "event", "feature"] }
+nix = {version = "0.29.0", default-features = false, features = ["aio", "event", "feature"] }
 sysctl = "0.1"
 tempfile = "3.4"
 


### PR DESCRIPTION
All mio-aio types now have an associated lifetime that references a BorrowedFd.