### PR TITLE
Use 2021 edition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mio-aio"
-edition = "2018"
+edition = "2021"
 version = "0.9.0"
 authors = ["Alan Somers <asomers@gmail.com>"]
 license = "MIT/Apache-2.0"


### PR DESCRIPTION
With the new resolver, nix will be built without the "feature" feature.