### PR TITLE
Raise MSRV to 1.71.0

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -12,7 +12,7 @@ task:
         VERSION: nightly
     - name: FreeBSD 13 amd64 MSRV
       env:
-        VERSION: 1.70.0
+        VERSION: 1.71.0
   # Install Rust
   setup_script:
     - fetch https://sh.rustup.rs -o rustup.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,9 @@
 
 ### Changed
 
-- Updated mio dependency to 1.0.  This also raises MSRV to 1.70.0
+- Updated mio dependency to 1.0.  This also raises MSRV to 1.71.0
   (#[49](https://github.com/asomers/mio-aio/pull/49))
+  (#[50](https://github.com/asomers/mio-aio/pull/50))
 
 ## [0.9.0] - [2024-05-24]
 


### PR DESCRIPTION
Because our main dependency, mio, just did.