### PR TITLE
SourceApi::register_raw now takes a BorrowedFd argument

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,5 +1,5 @@
 freebsd_instance:
-  image: freebsd-13-5-release-amd64
+  image: freebsd-14-4-release-amd64-ufs
 
 task:
   env:
@@ -7,10 +7,10 @@ task:
     # Temporary workaround for https://github.com/rust-lang/rustup/issues/2774
     RUSTUP_IO_THREADS: 1
   matrix:
-    - name: FreeBSD 13 amd64 nightly
+    - name: FreeBSD 14 amd64 nightly
       env:
         VERSION: nightly
-    - name: FreeBSD 13 amd64 MSRV
+    - name: FreeBSD 14 amd64 MSRV
       env:
         VERSION: 1.71.0
   # Install Rust

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,18 +1,10 @@
 freebsd_instance:
   image: freebsd-14-4-release-amd64-ufs
 
-task:
+setup: &SETUP
   env:
     HOME: /tmp  # cargo cache needs it
-    # Temporary workaround for https://github.com/rust-lang/rustup/issues/2774
-    RUSTUP_IO_THREADS: 1
-  matrix:
-    - name: FreeBSD 14 amd64 nightly
-      env:
-        VERSION: nightly
-    - name: FreeBSD 14 amd64 MSRV
-      env:
-        VERSION: 1.71.0
+    RUST_BACKTRACE: full  # Better info for debugging test failures
   # Install Rust
   setup_script:
     - fetch https://sh.rustup.rs -o rustup.sh
@@ -22,6 +14,25 @@ task:
   cargo_cache:
     folder: $HOME/.cargo/registry
     fingerprint_script: cat Cargo.lock || echo ""
+
+# Check that we compile with the MSRV.  But the tests don't need to.
+msrv_task:
+  name: FreeBSD 14 amd64 MSRV
+  env:
+    VERSION: 1.71.0
+  << : *SETUP
+  check_script:
+    - . $HOME/.cargo/env
+    - cargo +$VERSION build
+  before_cache_script: rm -rf $HOME/.cargo/registry/index
+
+nightly_task:
+  name: FreeBSD 14 amd64 nightly
+  env:
+    VERSION: nightly
+  << : *SETUP
+  nightly_setup_script:
+    pkg install -y cargo-audit
   test_script:
     - . $HOME/.cargo/env
     - cargo +$VERSION test
@@ -30,8 +41,6 @@ task:
     - if [ "$VERSION" = "nightly" ]; then cargo +$VERSION clippy --all-targets -- -D warnings; else true; fi
   audit_script:
     - . $HOME/.cargo/env
-    # install ca_root_nss due to https://github.com/rustsec/rustsec/issues/11
-    - pkg install -y ca_root_nss cargo-audit
     - cargo audit
   # Test our minimal version spec.
   minver_test_script:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## [Unrelease] - ReleaseDate
+
+### Changed
+
+- The `SourceApi::register_raw` method now takes a `BorrowedFd` argument
+  instead of a `RawFd`.  This is a breaking change.  This also raises the Nix
+  dependency to `>=0.30.0,<0.32.0` .
+  (#[51](https://github.com/asomers/mio-aio/pull/51))
+
 ## [1.0.0] - 2025-04-03
 
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,14 +26,14 @@ default = []
 tokio = []
 
 [dependencies]
-mio = "1"
-nix = {version = "0.29.0", default-features = false, features = ["aio", "event"] }
+mio = "1.2"
+nix = {version = ">=0.30.0,<0.32.0", default-features = false, features = ["aio", "event"] }
 pin-utils = "0.1.0"
 
 [dev-dependencies]
 assert-impl = "0.1"
-mio = { version = "1", features = ["os-poll"] }
-nix = {version = "0.29.0", default-features = false, features = ["aio", "event", "feature"] }
+mio = { version = "1.2", features = ["os-poll"] }
+nix = {version = ">=0.30.0,<0.32.0", default-features = false, features = ["aio", "event", "feature"] }
 sysctl = "0.6"
 tempfile = "3.4"
 

--- a/src/aio.rs
+++ b/src/aio.rs
@@ -1,7 +1,7 @@
 // vim: tw=80
 use std::{
     io::{self, IoSlice, IoSliceMut},
-    os::unix::io::{AsRawFd, BorrowedFd, RawFd},
+    os::{fd::AsFd, unix::io::BorrowedFd},
     pin::Pin,
 };
 
@@ -11,7 +11,7 @@ use nix::{
     libc::off_t,
     sys::{
         aio::{self, Aio},
-        event::EventFlag,
+        event::EvFlags,
         signal::SigevNotify,
     },
 };
@@ -57,7 +57,7 @@ pub trait SourceApi {
     /// Extra registration method needed by Tokio
     #[cfg(feature = "tokio")]
     #[cfg_attr(docsrs, doc(cfg(feature = "tokio")))]
-    fn register_raw(&mut self, kq: RawFd, udata: usize);
+    fn register_raw(&mut self, kq: BorrowedFd, udata: usize);
 
     /// Actually start the I/O operation.
     ///
@@ -83,11 +83,11 @@ impl<T: Aio> Source<T> {
         self.inner.set_sigev_notify(sigev);
     }
 
-    fn _register_raw(&mut self, kq: RawFd, udata: usize) {
+    fn _register_raw<'r>(&'r mut self, kq: BorrowedFd<'r>, udata: usize) {
         let sigev = SigevNotify::SigevKeventFlags {
             kq,
             udata: udata as isize,
-            flags: EventFlag::EV_ONESHOT,
+            flags: EvFlags::EV_ONESHOT,
         };
         self.inner.set_sigev_notify(sigev);
     }
@@ -118,7 +118,7 @@ impl<T: Aio> SourceApi for Source<T> {
     }
 
     #[cfg(feature = "tokio")]
-    fn register_raw(&mut self, kq: RawFd, udata: usize) {
+    fn register_raw(&mut self, kq: BorrowedFd, udata: usize) {
         self._register_raw(kq, udata)
     }
 
@@ -136,7 +136,7 @@ impl<T: Aio> event::Source for Source<T> {
     ) -> io::Result<()> {
         assert!(interests.is_aio());
         let udata = usize::from(token);
-        let kq = registry.as_raw_fd();
+        let kq = registry.as_fd();
         self._register_raw(kq, udata);
         Ok(())
     }


### PR DESCRIPTION
This finally brings I/O Safety to the kqueue.  This change also raises the Nix dependency, and will allow raising it further in the future.