### PR TITLE
ci: update FreeBSD workflow matrix to 15.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Start VM
         uses: vmactions/freebsd-vm@v1
         with:
-          release: ${{ matrix.freebsd_version }}
+          release: 15.1
           usesh: true
       - name: Install dependencies
         shell: freebsd {0}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,14 +21,14 @@ jobs:
             rust_version: "1.71.0"
           - freebsd_version: "14.4"
             rust_version: "nightly"
-          - freebsd_version: "15.0"
+          - freebsd_version: "15.1"
             rust_version: "nightly"
     steps:
       - uses: actions/checkout@v6
       - name: Start VM
         uses: vmactions/freebsd-vm@v1
         with:
-          release: 15.1
+          release: ${{ matrix.freebsd_version }}
           usesh: true
       - name: Install dependencies
         shell: freebsd {0}


### PR DESCRIPTION
Updates `.github/workflows/ci.yml` to use FreeBSD 15.1 by changing the `freebsd_version` value in the matrix.